### PR TITLE
add unique constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Community Package Cache
 
+[![Build Status](https://travis-ci.org/erasche/community-package-cache.svg)](https://travis-ci.org/erasche/community-package-cache)
+
 Because upstream is unreliable and URLs are mutable.
 
 ## Contributing

--- a/check.py
+++ b/check.py
@@ -43,11 +43,12 @@ with open(sys.argv[1], 'r') as handle:
                 log.error("[%s] Bad checksum %s", lineno, ld['sha'])
                 retcode = 1
 
-            if ld['id'] in identifier:
-                log.error("[%s] Identifier is not unique: '%s'", lineno, ld['id'])
+            platform_id = (ld['id'], ld['platform'], ld['arch'])
+            if platform_id in identifier:
+                log.error("[%s] Identifier is not unique: '%s'", lineno, platform_id)
                 retcode = 1
             else:
-                identifier.add( ld['id'] )
+                identifier.add(platform_id)
 
         except:
             log.error("[%s] Line not tabbed properly", lineno)

--- a/check.py
+++ b/check.py
@@ -7,6 +7,8 @@ log = logging.getLogger()
 
 with open(sys.argv[1], 'r') as handle:
     retcode = 0
+    identifier = set()
+
     for lineno, line in enumerate(handle):
         if line.startswith('#'):
             continue
@@ -40,6 +42,12 @@ with open(sys.argv[1], 'r') as handle:
             if len(ld['sha']) != 64:
                 log.error("[%s] Bad checksum %s", lineno, ld['sha'])
                 retcode = 1
+
+            if ld['id'] in identifier:
+                log.error("[%s] Identifier is not unique: '%s'", lineno, ld['id'])
+                retcode = 1
+            else:
+                identifier.add( ld['id'] )
 
         except:
             log.error("[%s] Line not tabbed properly", lineno)

--- a/check.py
+++ b/check.py
@@ -43,7 +43,7 @@ with open(sys.argv[1], 'r') as handle:
                 log.error("[%s] Bad checksum %s", lineno, ld['sha'])
                 retcode = 1
 
-            platform_id = (ld['id'], ld['platform'], ld['arch'])
+            platform_id = (ld['id'], ld['version'], ld['platform'], ld['arch'])
             if platform_id in identifiers:
                 log.error("[%s] identifier is not unique: '%s'", lineno, platform_id)
                 retcode = 1

--- a/check.py
+++ b/check.py
@@ -7,7 +7,7 @@ log = logging.getLogger()
 
 with open(sys.argv[1], 'r') as handle:
     retcode = 0
-    identifier = set()
+    identifiers = set()
 
     for lineno, line in enumerate(handle):
         if line.startswith('#'):
@@ -44,11 +44,11 @@ with open(sys.argv[1], 'r') as handle:
                 retcode = 1
 
             platform_id = (ld['id'], ld['platform'], ld['arch'])
-            if platform_id in identifier:
-                log.error("[%s] Identifier is not unique: '%s'", lineno, platform_id)
+            if platform_id in identifiers:
+                log.error("[%s] identifier is not unique: '%s'", lineno, platform_id)
                 retcode = 1
             else:
-                identifier.add(platform_id)
+                identifiers.add(platform_id)
 
         except:
             log.error("[%s] Line not tabbed properly", lineno)


### PR DESCRIPTION
The package ID should be unique in the file. The checksum does not need to be unique and is currently not unique in the tsv file. This is because of different packages referring to one tarball. If we want, we can get rid of this.

Depending on the [naming schema](https://github.com/erasche/community-package-cache/issues/3) we might change this constraint to column1+column3. So that we explicitly allow the same package name if it has a different architecture.

